### PR TITLE
Passes form values to entity hydration

### DIFF
--- a/src/Components/AjaxSelect/Entities/AbstractEntity.php
+++ b/src/Components/AjaxSelect/Entities/AbstractEntity.php
@@ -201,7 +201,7 @@ abstract class AbstractEntity
 							is_array($controlValue)
 								? $controlValue
 								: [ $controlValue ],
-							$control->getForm()->getUntrustedValues('array')
+							$control->getForm()->getValues('array')
 						)
 						: [],
 					'queryParam' => static::OPTION_QUERY,

--- a/src/Components/AjaxSelect/Entities/AbstractEntity.php
+++ b/src/Components/AjaxSelect/Entities/AbstractEntity.php
@@ -15,7 +15,7 @@ abstract class AbstractEntity
 	const OPTION_QUERY = 'q';
 
 	public abstract function formatValues($values): array;
-	public abstract function hydrateValues($values): array;
+	public abstract function hydrateValues($values, array $formValues = []): array;
 
 	protected abstract function createQueryObject(): QueryObject;
 
@@ -122,9 +122,9 @@ abstract class AbstractEntity
 	 * @param array $values
 	 * @return array List of items.
 	 */
-	public function formatJsonValues($values) {
+	public function formatJsonValues($values, array $formValues = []) {
 		$result = [ ];
-		$titles = $this->formatValues($values);
+		$titles = $this->formatValues($this->hydrateValues($values, $formValues));
 		$count = count($titles);
 		$i = 1;
 		foreach ($titles as $id => $item) {
@@ -200,7 +200,8 @@ abstract class AbstractEntity
 						? $this->formatJsonValues(
 							is_array($controlValue)
 								? $controlValue
-								: [ $controlValue ]
+								: [ $controlValue ],
+							$control->getForm()->getUntrustedValues('array')
 						)
 						: [],
 					'queryParam' => static::OPTION_QUERY,

--- a/src/Components/AjaxSelect/Traits/AjaxServiceControlTrait.php
+++ b/src/Components/AjaxSelect/Traits/AjaxServiceControlTrait.php
@@ -53,7 +53,7 @@ trait AjaxServiceControlTrait {
 			$validValues = array_merge($validValues, $invalidValues);
 		}
 
-		$validItems = $this->getAjaxEntity()->formatValues($this->getAjaxEntity()->hydrateValues($validValues));
+		$validItems = $this->getAjaxEntity()->formatValues($this->getAjaxEntity()->hydrateValues($validValues, $this->getForm()->getUntrustedValues('array')));
 
 		// add to list of valid values
 		$this->setItems($this->getItems() + $validItems);

--- a/src/Components/AjaxSelect/Traits/AjaxServiceControlTrait.php
+++ b/src/Components/AjaxSelect/Traits/AjaxServiceControlTrait.php
@@ -53,7 +53,7 @@ trait AjaxServiceControlTrait {
 			$validValues = array_merge($validValues, $invalidValues);
 		}
 
-		$validItems = $this->getAjaxEntity()->formatValues($this->getAjaxEntity()->hydrateValues($validValues, $this->getForm()->getUntrustedValues('array')));
+		$validItems = $this->getAjaxEntity()->formatValues($this->getAjaxEntity()->hydrateValues($validValues, $this->getForm()->getValues('array')));
 
 		// add to list of valid values
 		$this->setItems($this->getItems() + $validItems);


### PR DESCRIPTION
Ensures that form values are available during entity hydration, allowing for more context-aware data handling within the AjaxSelect component. This allows hydration logic to take form context into consideration when formatting JSON values, which ensures proper data handling and rendering of selected options.